### PR TITLE
fix: clean app names

### DIFF
--- a/pulumi/app/digitalocean/get-application-config.spec.ts
+++ b/pulumi/app/digitalocean/get-application-config.spec.ts
@@ -1,16 +1,12 @@
 import { getApplicationConfig } from "./get-application-config"
 
-jest.mock('./random', () => {
-  return {
-    randomString: () => "a1b2c3d4"
-  };
-});
+jest.mock('@common/random');
 
 describe("getApplicationConfig", () => {
   it("adds a specId", () => {
     const config = getApplicationConfig({ stackName: "dev", tag: "latest" });
     expect(config).toMatchObject({
-      specId: "chat-demo-dev/latest/a1b2c3d4",
+      specId: "chat-demo-dev/latest/a1a1a1a1",
     })
   })
 })

--- a/pulumi/app/digitalocean/get-application-config.ts
+++ b/pulumi/app/digitalocean/get-application-config.ts
@@ -1,7 +1,7 @@
 import * as entities from "@entities";
 import { GetApplicationConfig } from "@entities";
 import * as usecases from "@usecases";
-import { randomString } from "./random";
+import { randomString } from "@common/random";
 
 export type ApplicationConfig = entities.ApplicationConfig & {
   specId: string;
@@ -21,5 +21,5 @@ export const getApplicationConfig: GetApplicationConfig<ApplicationConfig> = (in
  * hasn't changed. Hence, generate a unique ID each time we provision.
  */
 const getSpecId = (appName: string, tag: string): string => {
-  return `${appName}/${tag}/${randomString()}`;
+  return `${appName}/${tag}/${randomString(4)}`;
 }

--- a/pulumi/app/digitalocean/random.ts
+++ b/pulumi/app/digitalocean/random.ts
@@ -1,3 +1,0 @@
-import * as crypto from "crypto";
-
-export const randomString = () => crypto.randomBytes(4).toString('hex');

--- a/pulumi/common/__mocks__/random.ts
+++ b/pulumi/common/__mocks__/random.ts
@@ -1,0 +1,1 @@
+export const randomString = (bytes: number) => "a1".repeat(bytes);

--- a/pulumi/common/random.ts
+++ b/pulumi/common/random.ts
@@ -1,0 +1,3 @@
+import * as crypto from "crypto";
+
+export const randomString = (bytes: number) => crypto.randomBytes(bytes).toString('hex');

--- a/pulumi/domain/usecases/get-application-config.spec.ts
+++ b/pulumi/domain/usecases/get-application-config.spec.ts
@@ -1,5 +1,7 @@
 import { getApplicationConfig } from "./get-application-config";
 
+jest.mock('@common/random');
+
 describe("getApplicationConfig", () => {
   it("returns the application configuration", () => {
     const inputs = {
@@ -64,7 +66,8 @@ describe("getApplicationConfig", () => {
   
     it("truncates names greater than 32 chars long", () => {
       const config = getApplicationConfig({ stackName: "deps-some-long-name-lib-3.x", tag });
-      expect(config.appName).toEqual("chat-demo-deps-some-long-name-li");
+      expect(config.appName).toEqual("chat-demo-deps-some-long-na-a1a1");
+      expect(config.appName.length).toEqual(32);
     });
   
     it("removes illegal characters", () => {

--- a/pulumi/domain/usecases/get-application-config.ts
+++ b/pulumi/domain/usecases/get-application-config.ts
@@ -1,4 +1,5 @@
 import { ApplicationInputs, Environment, GetApplicationConfig } from "@entities/application";
+import { randomString } from "@common/random";
 
 export const getApplicationConfig: GetApplicationConfig = (inputs: ApplicationInputs) => {
   const { stackName, tag } = inputs;
@@ -23,7 +24,12 @@ const getEnvironment = (stackName: string): Environment => {
 }
 
 const getAppName = (stackName: string): string => {
-  return `chat-demo-${cleanString(stackName)}`.slice(0, 32);
+  const cleanName = `chat-demo-${cleanString(stackName)}`;
+  if (cleanName.length > 32) {
+    const shortName = cleanName.slice(0, 27);
+    return `${shortName}-${randomString(2)}`;
+  }
+  return cleanName;
 }
 
 const cleanString = (s: string) => s.replace('/', '').replace('.', '');

--- a/pulumi/jest.config.js
+++ b/pulumi/jest.config.js
@@ -9,5 +9,6 @@ module.exports = {
     '^@usecases/(.*)$': '<rootDir>/domain/usecases/$1',
     '^@usecases$': '<rootDir>/domain/usecases',
     '^@app/(.*)$': '<rootDir>/app/$1',
+    '^@common/(.*)$': '<rootDir>/common/$1',
   },
 };

--- a/pulumi/tsconfig.json
+++ b/pulumi/tsconfig.json
@@ -18,6 +18,7 @@
           "@usecases": ["domain/usecases"],
           "@usecases/*": ["domain/usecases/*"],
           "@app/*": ["app/*"],
+          "@common/*": ["common/*"],
         }
     },
     "include": [
@@ -25,6 +26,7 @@
       "load-paths.ts",
       "domain/**/*.ts",
       "app/**/*.ts",
+      "common/**/*.ts",
     ],
     "ts-node": {
       "require": ["tsconfig-paths/register"]


### PR DESCRIPTION
This fixes two issues:

1. Errors like the below, where the truncated name fails DigitalOcean validation.
2. Cases where two long branch names might be truncated to the same name, by appending a random string to the end.

```
Diagnostics:
    pulumi:pulumi:Stack (chat-demo-deps-actions-checkout-3.x):
      stack config: {
       "stackName": "deps-actions-checkout-3.x",
       "appName": "chat-demo-deps-actions-checkout-",
       "environment": "development",
       "tag": "HEAD-2e[87](https://github.com/jbrunton/chat-demo/runs/6869966904?check_suite_focus=true#step:4:88)800",
       "protect": false,
       "specId": "chat-demo-deps-actions-checkout-/HEAD-2e87800/e[91](https://github.com/jbrunton/chat-demo/runs/6869966904?check_suite_focus=true#step:4:92)0a14f",
       "domain": "chat-demo-deps-actions-checkout-.chat-demo.dev.jbrunton-do.com",
       "publicUrl": "https://chat-demo-deps-actions-checkout-.chat-demo.dev.jbrunton-do.com",
       "rootDomain": "jbrunton-do.com"
      }
      error: update failed
  
    digitalocean:index:App (chat-demo-deps-actions-checkout-):
      error: 1 error occurred:
      	* Error creating App: POST https://api.digitalocean.com/v2/apps: 400 (request "863226d0-baae-4bd8-a730-b4307477f5b6") errors validating app spec; first error in field "domains.domain": domains.domain in body should match '^([a-zA-Z0-9]+(-+[a-zA-Z0-9]+)*\.)+(xn--)?[a-zA-Z0-9]{2,}\.?$'
  
  Outputs:
      publicUrl: "https://chat-demo-deps-actions-checkout-.chat-demo.dev.jbrunton-do.com"
```